### PR TITLE
Removed modules restored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 #Ignore
 *.js
 *.js.map
+*.ts
 
 #Allow
 !declarations.d.ts
+!/packages/lib/*.ts

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 #Ignore
 *.js
 *.js.map
-*.ts
 
 #Allow
 !declarations.d.ts

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -9,7 +9,61 @@
             "version": "1.0.5",
             "license": "MIT",
             "dependencies": {
-                "typescript": "^4.8.4"
+                "@types/react": "18.0.24",
+                "react": "18.2.0",
+                "typescript": "4.8.4"
+            }
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.8",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.8.tgz",
+            "integrity": "sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ=="
+        },
+        "node_modules/@types/react": {
+            "version": "18.0.24",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.24.tgz",
+            "integrity": "sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/scheduler": {
+            "version": "0.16.4",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
+            "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ=="
+        },
+        "node_modules/csstype": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/react": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/typescript": {
@@ -26,6 +80,52 @@
         }
     },
     "dependencies": {
+        "@types/prop-types": {
+            "version": "15.7.8",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.8.tgz",
+            "integrity": "sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ=="
+        },
+        "@types/react": {
+            "version": "18.0.24",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.24.tgz",
+            "integrity": "sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==",
+            "requires": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "@types/scheduler": {
+            "version": "0.16.4",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
+            "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ=="
+        },
+        "csstype": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "react": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "requires": {
+                "loose-envify": "^1.1.0"
+            }
+        },
         "typescript": {
             "version": "4.8.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,6 +24,8 @@
     },
     "homepage": "https://yakad.natiq.net",
     "dependencies": {
-        "typescript": "^4.8.4"
+        "typescript": "4.8.4",
+        "react": "18.2.0",
+        "@types/react": "18.0.24"
     }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yakad/lib",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "",
     "main": "./dist/index.js",
     "scripts": {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,4 +1,6 @@
 import joinClassNames from "./classnames";
 import joinStyles from "./styles";
+import useForm from "./useForm";
+import useFetch from "./useFetch";
 
-export { joinClassNames, joinStyles };
+export { joinClassNames, joinStyles, useForm, useFetch };

--- a/packages/lib/src/useFetch.ts
+++ b/packages/lib/src/useFetch.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+
+/**
+ * @description Custom Hook For handling Fetch
+ * @version 1.0
+ */
+function useFetch<ResponseType = object>(url: string, init: RequestInit) {
+    const [response, setResponse] = useState<Response>();
+    const [responseBody, setResponseBody] = useState<ResponseType>(
+        {} as ResponseType
+    );
+    const [error, setError] = useState<null | Error>(null);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [requestInit, setRequestInit] = useState<RequestInit>({});
+    const [isResponseBodyReady, setIsResponseBodyReady] = useState<boolean>(
+        false
+    );
+
+    useEffect(() => setRequestInit(init), [init.body]);
+
+    const send = () => {
+        setLoading(true);
+        setIsResponseBodyReady(false);
+
+        fetch(url, requestInit)
+            .then((response) => setResponse(response))
+            .catch((error) => setError(error));
+    };
+
+    useEffect(() => {
+        response
+            ?.clone()
+            ?.json()
+            .then((json) => setResponseBody(json))
+            .catch(() =>
+                response
+                    .text()
+                    .then((string) => setResponseBody(string as ResponseType))
+            )
+            .finally(() => {
+                setIsResponseBodyReady(true);
+                setLoading(false);
+            });
+    }, [response]);
+
+    return {
+        response,
+        send,
+        responseBody,
+        error,
+        loading,
+        isResponseBodyReady,
+    };
+}
+
+export default useFetch;

--- a/packages/lib/src/useForm.ts
+++ b/packages/lib/src/useForm.ts
@@ -1,0 +1,44 @@
+import React from "react";
+
+// useForm handle function type
+type HandleType = (
+    event:
+        | React.ChangeEvent<HTMLInputElement>
+        | React.FormEvent<HTMLFormElement>
+) => void;
+
+/**
+ * Handle's HTML forms
+ */
+export default function useForm<T = object>(initFormData?: T): [T, HandleType] {
+    let [formData, setFormData] = React.useState(initFormData);
+
+    const appendToState = (newValue: T) =>
+        setFormData((data) => ({ ...data, ...newValue }));
+
+    const handle = (
+        event:
+            | React.ChangeEvent<HTMLInputElement>
+            | React.FormEvent<HTMLFormElement>
+    ) => {
+        const eventAsInput = event as React.ChangeEvent<HTMLInputElement>;
+        const targetName = eventAsInput.target.name;
+        const targetType = eventAsInput.target.type;
+
+        if (targetType === "number") {
+            appendToState({
+                [targetName]: parseInt(eventAsInput.target.value, 10),
+            } as T);
+        }
+        else if (targetType === "checkbox") {
+            appendToState({
+                [targetName]: eventAsInput.target.checked,
+            } as T);
+        }
+        else {
+            appendToState({ [targetName]: eventAsInput.target.value } as T);
+        }
+    };
+
+    return [formData, handle]
+}


### PR DESCRIPTION
New changes:
1. Necessary modules (`useFetch`, `useForm`) restored, these modules are used in almost every frontend-related projects of the natiq
2. ReWrite the `useForm` module and make it clean and bug-free.
3. Install React package to `yakad/lib` package (`useForm` and `useFetch` modules need react functions)
4. Make an exception to the `.ts` files of `yakad/lib` package.
5. `useFetch` function version bumped to `1.0`
6. `yakad/lib` package version bumped to `1.0.6` **but not published to the npm**